### PR TITLE
fix: add width and height to body tag

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -21,7 +21,7 @@ import { ClientRouter } from "astro:transitions";
     <title>Sonnet Lamb - {title}</title>
     <ClientRouter />
   </head>
-  <body>
+  <body class="size-full">
     <Header />
     <main>
       <slot />


### PR DESCRIPTION
### Description

In this PR, I add a quick fix to a bug cause by adding `position: fixed;` to the body tag when mobile menu is opened.